### PR TITLE
Remove 32mscoff configuration

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -11,11 +11,6 @@
             "name": "secure"
 		},
 		{
-			"name": "32mscoff",
-			"dflags-windows-x86": ["-m32mscoff"],
-			"versions": ["mscoff"]
-		},
-		{
 			"name": "unittest",
 			"versions": ["EnableDebugger", "MemutilsTests"]
 		}


### PR DESCRIPTION
See https://github.com/etcimon/libasync/pull/75. The "mscoff" version constant doesn't appear to be used inside the code base.