### PR TITLE
Remove qualifiers from postblit and destructor.

### DIFF
--- a/source/memutils/refcounted.d
+++ b/source/memutils/refcounted.d
@@ -35,7 +35,7 @@ struct RefCounted(T, ALLOC = ThreadMem)
 	~this()
 	{
 		//logDebug("RefCounted dtor: ", T.stringof);
-		dtor((cast(RefCounted*)&this));
+		dtor(&this);
 	}
 	
 	static void dtor(U)(U* ctxt) {
@@ -53,7 +53,7 @@ struct RefCounted(T, ALLOC = ThreadMem)
 	this(this)
 	{
 		//logDebug("RefCounted copy ctor");
-		(cast(RefCounted*)&this).copyctor();
+		copyctor();
 	}
 	
 	void copyctor() {

--- a/source/memutils/refcounted.d
+++ b/source/memutils/refcounted.d
@@ -32,7 +32,7 @@ struct RefCounted(T, ALLOC = ThreadMem)
 		return ret;
 	}
 	
-	const ~this()
+	~this()
 	{
 		//logDebug("RefCounted dtor: ", T.stringof);
 		dtor((cast(RefCounted*)&this));
@@ -50,7 +50,7 @@ struct RefCounted(T, ALLOC = ThreadMem)
 		}
 	}
 	
-	const this(this)
+	this(this)
 	{
 		//logDebug("RefCounted copy ctor");
 		(cast(RefCounted*)&this).copyctor();


### PR DESCRIPTION
See https://github.com/dlang/dmd/pull/8032

Qualifiers on the destructor are currently still accepted, but in principle they should follow the same rule.